### PR TITLE
Add Meson build file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,33 @@
-language: d
+dist: trusty
 sudo: false
+
+language: d
+os:
+ - linux
+ - osx
+d:
+ - dmd
+ - dmd-beta
+ - dmd-nightly
+ - ldc
+ - ldc-beta
+
+before_install:
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install ninja python3; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then pip3 install meson; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then pip3 install meson; fi
+
+install:
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then mkdir .ntmp && curl -L https://github.com/ninja-build/ninja/releases/download/v1.7.2/ninja-linux.zip -o .ntmp/ninja-linux.zip; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then unzip .ntmp/ninja-linux.zip -d .ntmp; fi
+
+before_script:
+  - export PATH=$PATH:$PWD/.ntmp
+
+script:
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then meson build && ninja -C build; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then ninja -C build test -v; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then SDKROOT=$(xcodebuild -version -sdk macosx Path) meson build && ninja -C build test; fi
+  - dub build
+  - dub test

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,27 @@
+project('tinyendian', 'd', meson_version: '>=0.40.0')
+
+project_version      = '0.1.2'
+project_soversion    = '0'
+
+src_dir = include_directories('source/')
+pkgc = import('pkgconfig')
+
+tinyendian_src = [
+    'source/tinyendian.d'
+]
+install_headers(tinyendian_src, subdir: 'd/')
+
+tinyendian_lib = static_library('tinyendian',
+        [tinyendian_src],
+        include_directories: [src_dir],
+        install: true,
+        version: project_version,
+        soversion: project_soversion,
+        pic: true
+)
+pkgc.generate(name: 'tinyendian',
+              libraries: tinyendian_lib,
+              subdirs: 'd/',
+              version: project_version,
+              description: 'Lightweight endianness library for D.'
+)


### PR DESCRIPTION
This adds a Meson build file to the project. This allows building a static D library for tinyendian and makes it possible to use this project from other software that does not use dub (e.g. other stuff using Meson, or software using Automake).

I intend to use this together with D-YAML. It is reuired to get D-YAML into Debian at some point, as dub can not be used together with Debian's packaging systems.

More information about Meson can be found at: https://en.wikipedia.org/wiki/Meson_build_system

Thanks for considering!